### PR TITLE
Sanitize street addresses

### DIFF
--- a/uoftscrapers/scrapers/buildings/__init__.py
+++ b/uoftscrapers/scrapers/buildings/__init__.py
@@ -36,7 +36,8 @@ class Buildings(Scraper):
                 lat = self.get_value(building, 'lat', True)
                 lng = self.get_value(building, 'lng', True)
 
-                street = self.get_value(building, 'street')
+                street = ' '.join(filter(
+                    None, self.get_value(building, 'street').split(' ')))
                 city = self.get_value(building, 'city')
                 province = self.get_value(building, 'province')
                 country = self.get_value(building, 'country')


### PR DESCRIPTION
Some addresses had multiple spaces between street number and name. 

Here's an entry from the buildings [documentation](https://cobalt.qas.im/documentation/buildings/list):

``` json
{
    "id":"001",
    ...
    "address":{
      "street":"15  King's College Circle",
      "city":"Toronto",
      "province":"ON",
      "country":"Canada",
      "postal":"M5S 3H7"
    },
    ...
}
```

Added a simple filter to get rid of the extra spaces. 

``` json
{
    "id": "001",
    ...
    "address": {
        "street": "15 King's College Circle", 
        "city": "Toronto",
        "province": "ON", 
        "country": "Canada", 
        "postal": "M5S 3H7"
    },
    ...
}
```
