### PR TITLE
Remove unnecessary ensure_location calls

### DIFF
--- a/uoftscrapers/scrapers/buildings/__init__.py
+++ b/uoftscrapers/scrapers/buildings/__init__.py
@@ -23,7 +23,6 @@ class Buildings:
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('Buildings initialized.')
-        Scraper.ensure_location(location)
 
         for campus in Buildings.campuses:
             data = Buildings.get_map_json(campus)

--- a/uoftscrapers/scrapers/coursefinder/__init__.py
+++ b/uoftscrapers/scrapers/coursefinder/__init__.py
@@ -28,7 +28,6 @@ class CourseFinder:
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('CourseFinder initialized.')
-        Scraper.ensure_location(location)
 
         urls = CourseFinder.search()
         total = len(urls)

--- a/uoftscrapers/scrapers/exams/utm/__init__.py
+++ b/uoftscrapers/scrapers/exams/utm/__init__.py
@@ -27,9 +27,6 @@ class UTMExams:
         exams = UTMExams.retrieve_exams(courses)
         Scraper.logger.info('Got exams (3/3).')
 
-        if exams:
-            Scraper.ensure_location(location)
-
         for id_, doc in exams.items():
             Scraper.save_json(doc, location, id_)
 

--- a/uoftscrapers/scrapers/exams/utsc/__init__.py
+++ b/uoftscrapers/scrapers/exams/utsc/__init__.py
@@ -63,9 +63,6 @@ class UTSCExams:
                     'location': location_
                 })
 
-        if exams:
-            Scraper.ensure_location(location)
-
         for id_, doc in exams.items():
             Scraper.save_json(doc, location, id_)
 

--- a/uoftscrapers/scrapers/exams/utsg/__init__.py
+++ b/uoftscrapers/scrapers/exams/utsg/__init__.py
@@ -69,9 +69,6 @@ class UTSGExams:
                     ('location', location_)
                 ]))
 
-        if exams:
-            Scraper.ensure_location(location)
-
         for id_, doc in exams.items():
             Scraper.save_json(doc, location, id_)
 

--- a/uoftscrapers/scrapers/food/__init__.py
+++ b/uoftscrapers/scrapers/food/__init__.py
@@ -19,7 +19,6 @@ class Food:
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('Food initialized.')
-        Scraper.ensure_location(location)
 
         for campus, food_index in Food.campuses:
             data = LayersScraper.get_layers_json(campus)[food_index]

--- a/uoftscrapers/scrapers/scraper/__init__.py
+++ b/uoftscrapers/scrapers/scraper/__init__.py
@@ -36,13 +36,12 @@ class Scraper:
                 r = Scraper.s.get(url, params=params, cookies=cookies, headers=headers)
                 if r.status_code == 200:
                     html = r.text
-                return html.encode('utf-8')
             except (requests.exceptions.Timeout,
                     requests.exceptions.ConnectionError):
                 attempts += 1
                 continue
 
-        return html
+        return html.encode('utf-8') if html else None
 
     @staticmethod
     def flush_percentage(decimal):

--- a/uoftscrapers/scrapers/textbooks/__init__.py
+++ b/uoftscrapers/scrapers/textbooks/__init__.py
@@ -26,7 +26,6 @@ class Textbooks:
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('Food initialized.')
-        Scraper.ensure_location(location)
 
         terms = Textbooks.retrieve_terms()
         departments = Textbooks.retrieve_departments(terms)

--- a/uoftscrapers/scrapers/timetable/utsg/__init__.py
+++ b/uoftscrapers/scrapers/timetable/utsg/__init__.py
@@ -19,15 +19,14 @@ class UTSGTimetable:
         'F': 'FRIDAY',
         'S': 'SATURDAY'
     }
-    s = requests.Session()
     terms = ['summer', 'winter']
+    s = requests.Session()
 
     @staticmethod
     def scrape(location):
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('UTSGTimetable initialized.')
-        Scraper.ensure_location(location)
 
         for term in UTSGTimetable.terms:
             year = 0

--- a/uoftscrapers/scrapers/transportation/parking/utsg/__init__.py
+++ b/uoftscrapers/scrapers/transportation/parking/utsg/__init__.py
@@ -22,7 +22,6 @@ class UTSGParking:
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('UTSGParking initialized.')
-        Scraper.ensure_location(location)
 
         data = LayersScraper.get_layers_json('utsg')
 

--- a/uoftscrapers/scrapers/transportation/utmshuttle/__init__.py
+++ b/uoftscrapers/scrapers/transportation/utmshuttle/__init__.py
@@ -25,7 +25,6 @@ class UTMShuttle:
         """Update the local JSON files for this scraper."""
 
         Scraper.logger.info('UTMShuttle initialized.')
-        Scraper.ensure_location(location)
 
         now = datetime.datetime.now()
         year = now.strftime('%Y')


### PR DESCRIPTION
Since we call it when in `Scraper.save_json` before writing to the file.
