### PR TITLE
Add unique id key

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,8 @@ uoftscrapers.Athletics
 
 ##### Output format
 ```js
-{  
+{
+  "id": String,
   "date": String,
   "events":[{
     "title": String,

--- a/uoftscrapers/scrapers/athletics/utm.py
+++ b/uoftscrapers/scrapers/athletics/utm.py
@@ -29,6 +29,7 @@ class UTMAthletics:
         for tr in calendar.find_all('tr', class_='single-day'):
             for td in tr.find_all('td'):
                 date = td.get('data-date')
+                id_ = UTMAthletics.get_id(date)
 
                 if not UTMAthletics.date_in_month(date, month):
                     continue
@@ -56,13 +57,14 @@ class UTMAthletics:
                         ('end_time', end)
                     ]))
 
-                athletics[date] = OrderedDict([
+                athletics[id_] = OrderedDict([
+                    ('id', id_),
                     ('date', date),
                     ('events', events)
                 ])
 
-        for date, doc in athletics.items():
-            Scraper.save_json(doc, location, date)
+        for id_, doc in athletics.items():
+            Scraper.save_json(doc, location, id_)
 
         Scraper.logger.info('UTMAthletics completed.')
 
@@ -70,6 +72,11 @@ class UTMAthletics:
     def get_month(m):
         now = datetime.now()
         return '%s-%s' % (now.year, now.month)
+
+    @staticmethod
+    def get_id(d):
+        day = datetime.strptime(d, '%Y-%m-%d').day
+        return '%s%s' % (str(day).zfill(2), 'M')
 
     @staticmethod
     def date_in_month(d, m):

--- a/uoftscrapers/scrapers/athletics/utsc.py
+++ b/uoftscrapers/scrapers/athletics/utsc.py
@@ -29,6 +29,7 @@ class UTSCAthletics:
         for tr in calendar.find_all('tr', class_='single-day'):
             for td in tr.find_all('td'):
                 date = td.get('data-date')
+                id_ = UTSCAthletics.get_id(date)
 
                 if not UTSCAthletics.date_in_month(date, month):
                     continue
@@ -55,13 +56,14 @@ class UTSCAthletics:
                         ('end_time', end)
                     ]))
 
-                athletics[date] = OrderedDict([
+                athletics[id_] = OrderedDict([
+                    ('id', id_),
                     ('date', date),
                     ('events', events)
                 ])
 
-        for date, doc in athletics.items():
-            Scraper.save_json(doc, location, date)
+        for id_, doc in athletics.items():
+            Scraper.save_json(doc, location, id_)
 
         Scraper.logger.info('UTSCAthletics completed.')
 
@@ -69,6 +71,11 @@ class UTSCAthletics:
     def get_month(m):
         now = datetime.now()
         return '%s-%s' % (now.year, now.month)
+
+    @staticmethod
+    def get_id(d):
+        day = datetime.strptime(d, '%Y-%m-%d').day
+        return '%s%s' % (str(day).zfill(2), 'SC')
 
     @staticmethod
     def date_in_month(d, m):


### PR DESCRIPTION
Dates were overlapping for the 2 campuses, so data was being overwritten (see [this](https://github.com/cobalt-uoft/datasets/blob/master/athletics.json), only UTSC data is being exported). Add a unique ID key for each date. IDs are made up of date and campus identifier:
- UTM: end with `M`
  - April 1st => `01M`
- UTSC: end with `SC`
  - April 10th => `10SC`
