### PR TITLE
Dates Scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This is a library of scrapers for various University of Toronto websites. It is 
   - [Shuttle Bus Schedule](#shuttles)
   - [Events](#events)
   - [Libraries](#libraries)
+  - [Dates](#Dates)
+    - [UTSG Dates](#utsg-dates)
+    - [UTM Dates](#utm-dates)
 
 ## Requirements
  - [python3](https://www.python.org/download/releases/3.5.1)
@@ -692,3 +695,62 @@ https://onesearch.library.utoronto.ca/
   }
 }
 ```
+
+--------------------------------------------------------------------------------
+
+### Dates
+
+##### Class name
+```python
+uoftscrapers.Dates
+```
+
+##### Scraper source
+ - [UTSG Dates](#utsg-dates)
+ - [UTM Dates](#utm-dates)
+
+##### Output format
+```js
+{
+  "date": String,
+  "events": [{
+    "end_date": String,
+    "session": String,
+    "campus": String,
+    "description": String
+  }]
+}
+```
+
+----------------------------------------
+
+### UTSG Dates
+
+##### Class name
+```python
+uoftscrapers.UTSGDates
+```
+
+##### Scraper source
+http://www.artsci.utoronto.ca/current/course/timetable/
+http://www.undergrad.engineering.utoronto.ca/About/Dates_Deadlines.htm
+
+##### Output format
+Refer to [Exams](#exams)
+
+--------------------
+
+### UTM Dates
+
+##### Class name
+```python
+uoftscrapers.UTMDates
+```
+
+##### Scraper source
+http://m.utm.utoronto.ca/importantDates.php
+
+##### Output format
+Refer to [Exams](#exams)
+
+--------------------------------------------------------------------------------

--- a/uoftscrapers/__init__.py
+++ b/uoftscrapers/__init__.py
@@ -38,6 +38,8 @@ from .scrapers.events import Events
 
 from .scrapers.libraries import Libraries
 
+from .scrapers.dates import Dates
+
 class NullHandler(logging.Handler):
 
     def emit(self, record):

--- a/uoftscrapers/scrapers/athletics/utm.py
+++ b/uoftscrapers/scrapers/athletics/utm.py
@@ -74,4 +74,4 @@ class UTMAthletics:
                 Scraper.save_json(doc, location, id_)
 
         Scraper.logger.info('UTMAthletics completed.')
-        return athletics
+        return athletics if not save else None

--- a/uoftscrapers/scrapers/athletics/utsc.py
+++ b/uoftscrapers/scrapers/athletics/utsc.py
@@ -72,4 +72,5 @@ class UTSCAthletics:
                 Scraper.save_json(doc, location, id_)
 
         Scraper.logger.info('UTSCAthletics completed.')
-        return athletics
+
+        return athletics if not save else None

--- a/uoftscrapers/scrapers/calendar/utm.py
+++ b/uoftscrapers/scrapers/calendar/utm.py
@@ -4,76 +4,14 @@ from collections import OrderedDict
 import json
 import os
 import requests
-import datetime
 
 
 class UTMCalendar:
-    '''Scraper for Important dates from UTM calendar found at https://www.utm.utoronto.ca/registrar/important-dates
-        '''
 
-    link = 'http://m.utm.utoronto.ca/importantDates.php?mode=full&session={0}{1}&header='
-    sessionNumber = [5, 9]
+    host = 'http://www.artsandscience.utoronto.ca/ofr/calendar/'
+
     @staticmethod
-    def scrape(location='.', year=None): #scrapes most current sessions by default
-        
-        year = year or datetime.datetime.now().year
-
-        currentSession = "{0} SUMMER"
-        calendar = OrderedDict()
+    def scrape(location='.'):
         Scraper.logger.info('UTMCalendar initialized.')
-        for session in UTMCalendar.sessionNumber:
-            html = Scraper.get(UTMCalendar.link.format(year, session))
-            soup = BeautifulSoup(html, 'html.parser')
-            content = soup.find('div', class_='content')
-            dates = content.find_all('div', class_='title')
-            i = 0
-            currentDate = dates[i]
-            while(i<len(dates)):
-                date = dates[i].text
-                events = []
-                while (currentDate == dates[i]):
-                    info = dates[i].find_next('div', class_='info')
-                    description = info.text
-                    eventStartEnd = date.split('-') #splits event dates over a period
-                    eventStart = UTMCalendar.convert_date(eventStartEnd[0].strip())
-                    if len(eventStartEnd)>1:
-                        eventEnd = UTMCalendar.convert_date(eventStartEnd[1].strip())
-                    else:
-                        eventEnd = eventStart
-
-                    events.append(OrderedDict([
-                            ('end_date', eventEnd),
-                            ('session', currentSession.format(UTMCalendar.get_year_from(eventStart))),
-                            ('campus', 'UTM'),
-                            ('description', description)
-                        ]))
-                    i+=1
-                    if(i>=len(dates)):
-                        break;
-                calendar[date] = OrderedDict([
-                        ('date', eventStart),
-                        ('events', events)
-                    ])
-                if(i<len(dates)):
-                    currentDate = dates[i]
-            currentSession = "{0} FALL/WINTER"
-
-
-        for date, info in calendar.items():
-            Scraper.save_json(info, location, UTMCalendar.convert_date(date))
-
+        Scraper.logger.info('Not implemented.')
         Scraper.logger.info('UTMCalendar completed.')
-        return calendar
-
-    @staticmethod
-    def convert_date(date):
-        splitDate = date.split(' ')
-        year = splitDate[2]
-        day = splitDate[1].strip(',')
-        month = datetime.datetime.strptime(splitDate[0], '%B').strftime('%m')
-        return("{0}-{1}-{2}".format(year, month, day.zfill(2)))
-
-    @staticmethod
-    def get_year_from(date):
-        splitDate = date.split('-')
-        return splitDate[0]

--- a/uoftscrapers/scrapers/dates/__init__.py
+++ b/uoftscrapers/scrapers/dates/__init__.py
@@ -1,0 +1,11 @@
+from ..utils import Scraper
+from .utsg import UTSGDates
+
+
+class Dates:
+
+    @staticmethod
+    def scrape(location='.'):
+        Scraper.logger.info('Dates initialized.')
+        UTSGDates.scrape(location)
+        Scraper.logger.info('Dates completed.')

--- a/uoftscrapers/scrapers/dates/__init__.py
+++ b/uoftscrapers/scrapers/dates/__init__.py
@@ -1,11 +1,33 @@
 from ..utils import Scraper
 from .utsg import UTSGDates
+from .utm import UTMDates
+
+from collections import OrderedDict
 
 
 class Dates:
 
     @staticmethod
-    def scrape(location='.'):
+    def scrape(location='.', year=None):
         Scraper.logger.info('Dates initialized.')
-        UTSGDates.scrape(location)
+
+        docs = OrderedDict()
+
+        for campus in UTSGDates, UTMDates:
+            dates = campus.scrape(location, year=year, save=False)
+
+            if dates is None:
+                continue
+
+            for date, doc in dates.items():
+                if date not in docs:
+                    docs[date] = OrderedDict([
+                        ('date', date),
+                        ('events', [])
+                    ])
+                docs[date]['events'].extend(doc['events'])
+
+        for date, doc in docs.items():
+            Scraper.save_json(doc, location, date)
+
         Scraper.logger.info('Dates completed.')

--- a/uoftscrapers/scrapers/dates/utm.py
+++ b/uoftscrapers/scrapers/dates/utm.py
@@ -1,0 +1,79 @@
+from ..utils import Scraper
+from bs4 import BeautifulSoup
+from collections import OrderedDict
+import json
+import os
+import requests
+import datetime
+
+
+class UTMDates:
+    '''Scraper for Important dates from UTM calendar found at https://www.utm.utoronto.ca/registrar/important-dates
+        '''
+
+    link = 'http://m.utm.utoronto.ca/importantDates.php?mode=full&session={0}{1}&header='
+    sessionNumber = [5, 9]
+    @staticmethod
+    def scrape(location='.', year=None): #scrapes most current sessions by default
+
+        year = year or datetime.datetime.now().year
+
+        currentSession = "{0} SUMMER"
+        calendar = OrderedDict()
+        Scraper.logger.info('UTMDates initialized.')
+        for session in UTMDates.sessionNumber:
+            html = Scraper.get(UTMDates.link.format(year, session))
+            soup = BeautifulSoup(html, 'html.parser')
+            content = soup.find('div', class_='content')
+            dates = content.find_all('div', class_='title')
+            i = 0
+            currentDate = dates[i]
+            while(i<len(dates)):
+                date = dates[i].text
+                events = []
+                while (currentDate == dates[i]):
+                    info = dates[i].find_next('div', class_='info')
+                    description = info.text
+                    eventStartEnd = date.split('-') #splits event dates over a period
+                    eventStart = UTMDates.convert_date(eventStartEnd[0].strip())
+                    if len(eventStartEnd)>1:
+                        eventEnd = UTMDates.convert_date(eventStartEnd[1].strip())
+                    else:
+                        eventEnd = eventStart
+
+                    events.append(OrderedDict([
+                            ('end_date', eventEnd),
+                            ('session', currentSession.format(UTMDates.get_year_from(eventStart))),
+                            ('campus', 'UTM'),
+                            ('description', description)
+                        ]))
+                    i+=1
+                    if(i>=len(dates)):
+                        break;
+                calendar[date] = OrderedDict([
+                        ('date', eventStart),
+                        ('events', events)
+                    ])
+                if(i<len(dates)):
+                    currentDate = dates[i]
+            currentSession = "{0} FALL/WINTER"
+
+
+        for date, info in calendar.items():
+            Scraper.save_json(info, location, UTMDates.convert_date(date))
+
+        Scraper.logger.info('UTMDates completed.')
+        return calendar
+
+    @staticmethod
+    def convert_date(date):
+        splitDate = date.split(' ')
+        year = splitDate[2]
+        day = splitDate[1].strip(',')
+        month = datetime.datetime.strptime(splitDate[0], '%B').strftime('%m')
+        return("{0}-{1}-{2}".format(year, month, day.zfill(2)))
+
+    @staticmethod
+    def get_year_from(date):
+        splitDate = date.split('-')
+        return splitDate[0]

--- a/uoftscrapers/scrapers/dates/utm.py
+++ b/uoftscrapers/scrapers/dates/utm.py
@@ -14,7 +14,7 @@ class UTMDates:
     link = 'http://m.utm.utoronto.ca/importantDates.php?mode=full&session={0}{1}&header='
     sessionNumber = [5, 9]
     @staticmethod
-    def scrape(location='.', year=None): #scrapes most current sessions by default
+    def scrape(location='.', year=None, save=True):  # scrapes most current sessions by default
 
         year = year or datetime.datetime.now().year
 
@@ -28,15 +28,15 @@ class UTMDates:
             dates = content.find_all('div', class_='title')
             i = 0
             currentDate = dates[i]
-            while(i<len(dates)):
+            while(i < len(dates)):
                 date = dates[i].text
                 events = []
                 while (currentDate == dates[i]):
                     info = dates[i].find_next('div', class_='info')
                     description = info.text
-                    eventStartEnd = date.split('-') #splits event dates over a period
+                    eventStartEnd = date.split('-')  # splits event dates over a period
                     eventStart = UTMDates.convert_date(eventStartEnd[0].strip())
-                    if len(eventStartEnd)>1:
+                    if len(eventStartEnd) > 1:
                         eventEnd = UTMDates.convert_date(eventStartEnd[1].strip())
                     else:
                         eventEnd = eventStart
@@ -47,23 +47,23 @@ class UTMDates:
                             ('campus', 'UTM'),
                             ('description', description)
                         ]))
-                    i+=1
-                    if(i>=len(dates)):
-                        break;
-                calendar[date] = OrderedDict([
-                        ('date', eventStart),
-                        ('events', events)
-                    ])
-                if(i<len(dates)):
+                    i += 1
+                    if(i >= len(dates)):
+                        break
+                calendar[eventStart] = OrderedDict([
+                    ('date', eventStart),
+                    ('events', events)
+                ])
+                if(i < len(dates)):
                     currentDate = dates[i]
             currentSession = "{0} FALL/WINTER"
 
-
-        for date, info in calendar.items():
-            Scraper.save_json(info, location, UTMDates.convert_date(date))
+        if save:
+            for date, info in calendar.items():
+                Scraper.save_json(info, location, UTMDates.convert_date(date))
 
         Scraper.logger.info('UTMDates completed.')
-        return calendar
+        return calendar if not save else None
 
     @staticmethod
     def convert_date(date):

--- a/uoftscrapers/scrapers/dates/utsg.py
+++ b/uoftscrapers/scrapers/dates/utsg.py
@@ -1,0 +1,55 @@
+from ..utils import Scraper
+from bs4 import BeautifulSoup
+from collections import OrderedDict
+from datetime import datetime
+from pytz import timezone
+
+
+class UTSGDates:
+    """A scraper for UTSG important dates.
+
+    Data is retrieved from http://www.artsci.utoronto.ca/current/course/timetable/.
+    """
+
+    @staticmethod
+    def scrape(location='.'):
+        Scraper.logger.info('UTSGDates initialized.')
+
+        for faculty in ArtSciDates, EngDates:
+            dates = faculty.scrape(location)
+            if dates is not None:
+                # save json file
+                pass
+
+        Scraper.logger.info('UTSGDates completed.')
+
+
+class ArtSciDates:
+    """A scraper for important dates for the Faculty of Arts & Science.
+
+    Data is retrieved from http://www.artsci.utoronto.ca/current/course/timetable/.
+    """
+
+    @staticmethod
+    def scrape(location='.', year=None):
+        """Update the local JSON files for this scraper."""
+        Scraper.logger.info('ArtSciDates initialized.')
+
+        year = year[2:] or datetime.now().strftime('%y')
+
+        Scraper.logger.info('ArtSciDates completed.')
+
+
+class EngDates:
+    """A scraper for important dates for UTSG Engineering.
+
+    Data is retrieved from http://www.undergrad.engineering.utoronto.ca/About/Dates_Deadlines.htm.
+    """
+
+    @staticmethod
+    def scrape(location='.'):
+        """Update the local JSON files for this scraper."""
+        Scraper.logger.info('EngDates initialized.')
+
+        Scraper.logger.info('EngDates completed.')
+

--- a/uoftscrapers/scrapers/dates/utsg.py
+++ b/uoftscrapers/scrapers/dates/utsg.py
@@ -3,53 +3,167 @@ from bs4 import BeautifulSoup
 from collections import OrderedDict
 from datetime import datetime
 from pytz import timezone
+from pprint import pprint
+import re
 
 
 class UTSGDates:
-    """A scraper for UTSG important dates.
-
-    Data is retrieved from http://www.artsci.utoronto.ca/current/course/timetable/.
-    """
+    """A scraper for UTSG important dates."""
 
     @staticmethod
     def scrape(location='.'):
         Scraper.logger.info('UTSGDates initialized.')
 
         for faculty in ArtSciDates, EngDates:
-            dates = faculty.scrape(location)
-            if dates is not None:
-                # save json file
-                pass
+            docs = faculty.scrape(location, save=False)
+            if docs is not None:
+                for date, doc in docs.items():
+                    Scraper.save_json(doc, location, date)
 
         Scraper.logger.info('UTSGDates completed.')
 
 
 class ArtSciDates:
-    """A scraper for important dates for the Faculty of Arts & Science.
+    """A scraper for important dates for UTSG Arts & Science.
 
-    Data is retrieved from http://www.artsci.utoronto.ca/current/course/timetable/.
+    Data is retrieved from
+    http://www.artsci.utoronto.ca/current/course/timetable/.
     """
 
+    host = 'http://www.artsci.utoronto.ca/current/course/timetable/'
+
     @staticmethod
-    def scrape(location='.', year=None):
+    def scrape(location='.', year=None, save=True):
         """Update the local JSON files for this scraper."""
         Scraper.logger.info('ArtSciDates initialized.')
 
-        year = year[2:] or datetime.now().strftime('%y')
+        for session, endpoint in ArtSciDates.get_sessions(year)[:1]:
+            headers = {
+                'Referer': ArtSciDates.host
+            }
+            html = Scraper.get('%s%s' % (ArtSciDates.host, endpoint),
+                               headers=headers,
+                               max_attempts=3)
+
+            if html is None:
+                Scraper.logger.info('No data available for %s.' % session.upper)
+                continue
+
+            docs = OrderedDict()
+
+            soup = BeautifulSoup(html, 'html.parser')
+            for tr in soup.find(class_='vertical listing').find_all('tr'):
+                if tr.find('th'):
+                    continue
+
+                event = tr.find_all('td')
+
+                start_date, end_date = ArtSciDates.parse_dates(event[0].text, session)
+
+                events = []
+                for t in event[1].text.split(';\n'):
+                    events += ArtSciDates.normalize_text(t)
+
+                doc = OrderedDict([
+                    ('start_date', start_date),
+                    ('end_date', end_date),
+                    ('session', session),
+                    ('events', events)
+                ])
+
+                if start_date not in docs:
+                    docs[start_date] = doc
+                else:
+                    docs[start_date]['events'].extend(doc['events'])
+
+        if save:
+            for date, doc in docs.items():
+                Scraper.save_json(doc, location, date)
 
         Scraper.logger.info('ArtSciDates completed.')
+        return docs
+
+    @staticmethod
+    def normalize_text(text):
+        text = re.sub(r'\s\s+', ' ', text).strip()
+
+        if text == '':
+            return []
+
+        if '\n' in text and text[-2:] != '\n':
+            return text.split('\n')
+
+        return [text]
+
+    @staticmethod
+    def get_sessions(year):
+        try:
+            date = datetime(year=year)
+        except:
+            year = None
+
+        if year is None:
+            year = datetime.now().strftime('%Y')
+
+        shortened_year = str(year)[2:]
+        session = '%s%d_fw' % (shortened_year, int(shortened_year) + 1)
+
+        fall = '%s/%s_fall_dates' % (session, str(year))
+        winter = '%s/%d_winter_dates' % (session, int(year) + 1)
+
+        summer = '%s5/dates' % year
+
+        return [
+            ('FALL%s' % shortened_year, fall),
+            ('WINTER%s' % shortened_year, winter),
+            ('SUMMER%s' % shortened_year, summer)
+        ]
+
+    @staticmethod
+    def parse_dates(date, session):
+        def get_date(date_string):
+            # date_string in the form '%B %d'
+            month = date_string.split(' ')[0]
+            year = int(session[-2:])
+            if 'FALL' in session and int(datetime.strptime(month, '%B').strftime('%m')) < 4:
+                year += 1
+
+            return '%s %d' % (date_string, year)
+
+        start = end = None
+        if '-' in date:
+            # Date range
+            if ' - ' in date:
+                # e.g. December 21 - January 4
+                date = date.split(' - ')
+
+                start, end = get_date(date[0]), get_date(date[1])
+            else:
+                # e.g. November 7-8
+                month, days = date.split(' ')
+                days = days.split('-')
+
+                start = get_date('%s %s' % (month, days[0]))
+                end = get_date('%s %s' % (month, days[1]))
+        else:
+            start = end = get_date(date)
+
+        start = datetime.strptime(start, '%B %d %y').date().isoformat()
+        end = datetime.strptime(end, '%B %d %y').date().isoformat()
+
+        return start, end
 
 
 class EngDates:
     """A scraper for important dates for UTSG Engineering.
 
-    Data is retrieved from http://www.undergrad.engineering.utoronto.ca/About/Dates_Deadlines.htm.
+    Data is retrieved from
+    http://www.undergrad.engineering.utoronto.ca/About/Dates_Deadlines.htm.
     """
 
     @staticmethod
-    def scrape(location='.'):
+    def scrape(location='.', save=True):
         """Update the local JSON files for this scraper."""
         Scraper.logger.info('EngDates initialized.')
 
         Scraper.logger.info('EngDates completed.')
-

--- a/uoftscrapers/scrapers/exams/utsg.py
+++ b/uoftscrapers/scrapers/exams/utsg.py
@@ -115,7 +115,7 @@ class ArtSciExams:
                 Scraper.save_json(doc, location, id_)
 
         Scraper.logger.info('ArtSciExams completed.')
-        return exams
+        return exams if not save else None
 
     @staticmethod
     def parse_course_info(period, course_code):
@@ -272,7 +272,7 @@ class EngExams:
                 Scraper.save_json(doc, location, id_)
 
         Scraper.logger.info('EngExams completed.')
-        return exams
+        return exams if not save else None
 
     @staticmethod
     def get_course_info(course, period):


### PR DESCRIPTION
- `UTMCalendar` changed to `UTMDates`
- Add `UTSGDates`
  - `ArtSciDates` - http://www.artsci.utoronto.ca/current/course/timetable/
  - `EngDates` - http://www.undergrad.engineering.utoronto.ca/About/Dates_Deadlines.htm
    - Sometimes this calendar throws a "cannot find content" error (while scraping), but response status is still `200`. Right now, it makes 5 attempts and ignores that month if those fail. Could it be the request headers?
    - I was unsure what the `session` should be for this scraper – it's currently `<YEAR> ENGINEERING`. We could choose a session (fall/winter/summer) based on the month, but we may run into some odd cases (this is completely hypothetical):
      
      ``` js
      {
        "date": "2016-04-05",
        "events": [{
          "end_date": "2016-04-05",
          "session": "2016 WINTER",
          "campus": "UTSG",
          "description": "First day for course enrolment for the summer term." // in ArtSci, UTM this would fall under the `2016 SUMMER` session.
        }]
      }
      ```
