### PR TITLE
View breadth requirements for UTSC courses

### DIFF
--- a/uoftscrapers/scrapers/courses/__init__.py
+++ b/uoftscrapers/scrapers/courses/__init__.py
@@ -124,16 +124,33 @@ class Courses:
 
         # Things that don't appear on all courses
 
+        # If Campus is UTSG, find Breadths
         as_breadth = soup.find(id="u122")
         breadths = []
-        if as_breadth is not None:
+        if as_breadth is not None and campus == "UTSG":
             as_breadth = as_breadth.find_all("span", id="u122")[0] \
                 .get_text().strip()
             for ch in as_breadth:
                 if ch in "12345":
                     breadths.append(int(ch))
+            breadths = sorted(breadths)
 
-        breadths = sorted(breadths)
+        # If Campus is UTSC, find Breadths
+        utsc_breadth = soup.find(id="u104")
+        if utsc_breadth is not None and campus == "UTSC":
+            utsc_breadth = utsc_breadth.find_all("span", id="u104")[0] \
+                .get_text().strip()
+
+            if utsc_breadth == "Arts, Literature & Language":
+                breadths.append(1)
+            elif utsc_breadth == "History, Philosophy & Cultural Studies":
+                breadths.append(2)
+            elif utsc_breadth == "Natural Sciences":
+                breadths.append(3)
+            elif utsc_breadth == "Social & Behavioural Sciences":
+                breadths.append(4)
+            elif utsc_breadth == "Quantitative Reasoning":
+                breadths.append(5)
 
         exclusions = soup.find(id="u68")
         if exclusions is not None:

--- a/uoftscrapers/scrapers/courses/__init__.py
+++ b/uoftscrapers/scrapers/courses/__init__.py
@@ -133,24 +133,24 @@ class Courses:
             for ch in as_breadth:
                 if ch in "12345":
                     breadths.append(int(ch))
-            breadths = sorted(breadths)
 
         # If Campus is UTSC, find Breadths
+        utsc_breadths_dict = {"Arts, Literature & Language": 1,
+                              "History, Philosophy & Cultural Studies": 2,
+                              "Natural Sciences": 3,
+                              "Social & Behavioural Sciences": 4,
+                              "Quantitative Reasoning": 5}
+
         utsc_breadth = soup.find(id="u104")
         if utsc_breadth is not None and campus == "UTSC":
             utsc_breadth = utsc_breadth.find_all("span", id="u104")[0] \
                 .get_text().strip()
 
-            if utsc_breadth == "Arts, Literature & Language":
-                breadths.append(1)
-            elif utsc_breadth == "History, Philosophy & Cultural Studies":
-                breadths.append(2)
-            elif utsc_breadth == "Natural Sciences":
-                breadths.append(3)
-            elif utsc_breadth == "Social & Behavioural Sciences":
-                breadths.append(4)
-            elif utsc_breadth == "Quantitative Reasoning":
-                breadths.append(5)
+            if utsc_breadth in utsc_breadths_dict:
+                breadths.append(utsc_breadths_dict[utsc_breadth])
+
+        # sort the breadths in the end
+        breadths = sorted(breadths)
 
         exclusions = soup.find(id="u68")
         if exclusions is not None:

--- a/uoftscrapers/scrapers/courses/__init__.py
+++ b/uoftscrapers/scrapers/courses/__init__.py
@@ -124,30 +124,30 @@ class Courses:
 
         # Things that don't appear on all courses
 
-        # If Campus is UTSG, find Breadths
-        as_breadth = soup.find(id="u122")
         breadths = []
-        if as_breadth is not None and campus == "UTSG":
-            as_breadth = as_breadth.find_all("span", id="u122")[0] \
-                .get_text().strip()
-            for ch in as_breadth:
-                if ch in "12345":
-                    breadths.append(int(ch))
-
+        # If Campus is UTSG, find Breadths
+        if campus == "UTSG":
+            as_breadth = soup.find(id="u122")
+            if as_breadth is not None:
+                as_breadth = as_breadth.find_all("span", id="u122")[0] \
+                    .get_text().strip()
+                for ch in as_breadth:
+                    if ch in "12345":
+                        breadths.append(int(ch))
         # If Campus is UTSC, find Breadths
-        utsc_breadths_dict = {"Arts, Literature & Language": 1,
-                              "History, Philosophy & Cultural Studies": 2,
-                              "Natural Sciences": 3,
-                              "Social & Behavioural Sciences": 4,
-                              "Quantitative Reasoning": 5}
+        elif campus == "UTSC":
+            utsc_breadths_dict = {"Arts, Literature & Language": 1,
+                                  "History, Philosophy & Cultural Studies": 2,
+                                  "Natural Sciences": 3,
+                                  "Social & Behavioural Sciences": 4,
+                                  "Quantitative Reasoning": 5}
+            utsc_breadth = soup.find(id="u104")
+            if utsc_breadth is not None:
+                utsc_breadth = utsc_breadth.find_all("span", id="u104")[0] \
+                    .get_text().strip()
 
-        utsc_breadth = soup.find(id="u104")
-        if utsc_breadth is not None and campus == "UTSC":
-            utsc_breadth = utsc_breadth.find_all("span", id="u104")[0] \
-                .get_text().strip()
-
-            if utsc_breadth in utsc_breadths_dict:
-                breadths.append(utsc_breadths_dict[utsc_breadth])
+                if utsc_breadth in utsc_breadths_dict:
+                    breadths.append(utsc_breadths_dict[utsc_breadth])
 
         # sort the breadths in the end
         breadths = sorted(breadths)


### PR DESCRIPTION
This change will allow for courses that are at UTSC to have breadth requirements. Previously the scraper would only fetch breadths for UTSG courses. I have changed that now so we can populate breadths for UTSC courses as well. It still holds the model validations so "breadths" is still a list of numbers. 

For UTSC, the numbers correspond the breadth in this fashion:
1 => Arts, Literature & Language
2 => "History, Philosophy & Cultural Studies"
3 => "Natural Sciences"
4 => "Social & Behavioural Sciences"
5 => "Quantitative Reasoning"

UTSC courses don't have more than one breadth so I feel this change should work for all courses at UTSC. I have tested it and confirmed the outputted data to be correct.